### PR TITLE
Simple executable to install python module

### DIFF
--- a/install_python
+++ b/install_python
@@ -1,0 +1,17 @@
+command_exists()
+{
+    command -v "$1" >/dev/null 2>&1
+}
+
+if command_exists swig; then
+    {
+        cd Python
+        swig -python -c++ breakout_detection.i
+        python setup.py build_ext -I../src build
+        python setup.py build_ext -I../src install
+        echo "testing module..."
+        python test.py
+    }
+else
+    echo "error: please install swig"
+fi


### PR DESCRIPTION
Although the GitHub readme has instructions on how to install and setup the breakout python module, why not add a simple executable that people can use to install the module. The executable simply checks if swig is installed and if it is, then it follows the readme and runs the same commands.